### PR TITLE
spec2 クーポンテーブルにuserカラムをもたせた

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-debug.log*
 .yarn-integrity
 /config/cloudinary.yml
 .env
+/spec/examples.txt

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
     if admin_signed_in?
       admins_items_path
     else
-      items_path
+      root_path
     end
   end
 

--- a/app/controllers/users/coupons_controller.rb
+++ b/app/controllers/users/coupons_controller.rb
@@ -9,7 +9,7 @@ class Users::CouponsController < ApplicationController
 
   def create
     if @coupon = Coupon.find_by(code: params[:coupon][:code])
-      if @coupon.used
+      if @coupon.used?
         @coupon.errors.add(:code, 'コードはすでに使用されています')
         render :new
       end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -1,5 +1,6 @@
 class Coupon < ApplicationRecord
   before_validation :generate_code
+  belongs_to :user, optional: true
 
   scope :recent, -> { order(created_at: :desc) }
 
@@ -12,7 +13,11 @@ class Coupon < ApplicationRecord
   end
 
   def display_used
-    self.used ? '使用済み' : '未使用'
+    self.used? ? '使用済み' : '未使用'
+  end
+
+  def used?
+    self.user.present?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   end
 
   def charge_coupon(coupon)
-    raise '使用済みのコードです' if coupon.used?
+    return '使用済みのコードです' if coupon.used?
     ActiveRecord::Base.transaction do
       self.point += coupon.point
       save!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :goods, dependent: :destroy
 
+  has_many :coupons, dependent: :destroy
+
   scope :normal, -> { where(admin: false) }
   scope :recent, -> { order(created_at: :desc) }
 
@@ -17,9 +19,11 @@ class User < ApplicationRecord
   end
 
   def charge_coupon(coupon)
-    raise '使用済みのコードです' if self.used
-    self.point += coupon.point
-    self.used  = true
-    save
+    raise '使用済みのコードです' if coupon.used?
+    ActiveRecord::Base.transaction do
+      self.point += coupon.point
+      save!
+      coupon.update!(user: self)
+    end
   end
 end

--- a/app/views/admins/coupons/index.html.haml
+++ b/app/views/admins/coupons/index.html.haml
@@ -7,6 +7,7 @@
     %th コード
     %th ポイント数
     %th 使用済み
+    %th 使用したユーザー
     %th
   %tbody
     - @coupons.each do |coupon|
@@ -14,5 +15,6 @@
         %td= link_to coupon.display_code, admins_coupon_path(coupon)
         %td= coupon.point
         %td= coupon.display_used
+        %td= coupon.user.display_name if coupon.used?
         %td
           =link_to '削除', admins_coupon_path(coupon), method: :delete, data: {confirm: '削除しますか？'}

--- a/db/migrate/20200526082753_remove_used_flag_from_coupons.rb
+++ b/db/migrate/20200526082753_remove_used_flag_from_coupons.rb
@@ -1,0 +1,9 @@
+class RemoveUsedFlagFromCoupons < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :coupons, :used
+  end
+
+  def down
+    add_column :coupons, :used, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20200526091327_add_user_ref_to_coupons.rb
+++ b/db/migrate/20200526091327_add_user_ref_to_coupons.rb
@@ -1,0 +1,5 @@
+class AddUserRefToCoupons < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :coupons, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_24_112020) do
+ActiveRecord::Schema.define(version: 2020_05_26_091327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,10 +43,11 @@ ActiveRecord::Schema.define(version: 2020_05_24_112020) do
   create_table "coupons", force: :cascade do |t|
     t.integer "point", default: 0, null: false
     t.string "code", null: false
-    t.boolean "used", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
     t.index ["code"], name: "index_coupons_on_code", unique: true
+    t.index ["user_id"], name: "index_coupons_on_user_id"
   end
 
   create_table "goods", force: :cascade do |t|
@@ -125,6 +126,7 @@ ActiveRecord::Schema.define(version: 2020_05_24_112020) do
   add_foreign_key "cart_items", "items"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "coupons", "users"
   add_foreign_key "goods", "posts"
   add_foreign_key "goods", "users"
   add_foreign_key "order_items", "items"

--- a/spec/factories/coupons.rb
+++ b/spec/factories/coupons.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :coupon do
     point { 500 }
     code { Coupon::generate_code }
-    used { false }
   end
 end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Coupon, type: :model do
+  let!(:user) { create(:user) }
+  let!(:coupon) { create(:coupon) }
+
+  it 'つかったクーポンコードは使用済みになる' do
+    expect(user.coupons.count).to eq 0
+
+    user.charge_coupon(coupon)
+    expect(user.coupons.find(coupon.id)).to be_truthy
+    expect(coupon.user.present?).to be_truthy
+
+    expect(coupon.used?).to be_truthy
+    expect(user.coupons.count).to eq 1
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   let! (:user) { create(:user) }
   let! (:coupon_100) { create(:coupon, point: 100) }
-  let! (:used_coupon) { create(:coupon, used: true) }
+  let! (:used_coupon) { create(:coupon, user: user) }
 
   it 'ユーザーは、コードを入力してポイントを受け取れる' do
     expect(user.point).to eq 0

--- a/spec/system/coupons_spec.rb
+++ b/spec/system/coupons_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Coupons", type: :system do
 
     fill_in 'ポイント', with: '500'
     expect {
-      click_on '発行する'
+      click_on '登録する'
       expect(page).to have_content 'クーポンコードを発行しました'
     }.to change { Coupon.count }.by(1)
 
@@ -39,6 +39,32 @@ RSpec.describe "Coupons", type: :system do
       }.to change { user.point }.by(500)
 
     end
+
+
   end
 
+  context '管理者でログインしているとき' do
+    let!(:admin){ create(:admin) }
+    let!(:user){ create(:user) }
+    let!(:coupon){ create(:coupon, point: 999) }
+    before { sign_in admin }
+    it 'クーポンの利用状況が確認できる' do
+      visit admins_coupons_path
+
+      within first('tbody > tr') do
+        expect(page).to have_content 999
+        expect(page).to have_content '未使用'
+      end
+
+      user.charge_coupon(coupon)
+
+      visit admins_coupons_path
+
+      within first('tbody > tr') do
+        expect(page).to have_content 999
+        expect(page).to have_content '使用済み'
+        expect(page).to have_content user.display_name
+      end
+    end
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Users", type: :system do
       visit admins_coupons_path
       expect {
         first('tbody tr').click_link '削除'
-        expect(page.driver.browser.switch_to.alert.text).to eq '削除してよろしいですか？'
+        expect(page.driver.browser.switch_to.alert.text).to eq '削除しますか？'
         page.accept_confirm
         expect(current_path).to eq admins_coupons_path
       }.to change { Coupon.count }.by(-1)


### PR DESCRIPTION
- coupon.used カラムを廃止して、coupon.user（null: true）に置き換えた
- クーポンコードのテスト追加
- 細かな不具合修正
- テスト失敗箇所の修正

### MEMO
最初、UserCouponsというテーブルをつくったが、User:Couponは多対多ではなかった。（Couponは1人のユーザーしか持たないため）
Couponに`has_one :user, optional: true`を追加して、ユーザーがクーポンを使ったときに関連付くように修正した。

tag
https://github.com/hirocueki/ec_market/releases/tag/add-user-ref-to-coupons